### PR TITLE
Narrow the scope of the unsafe blocks

### DIFF
--- a/src/bitmap_glyph.rs
+++ b/src/bitmap_glyph.rs
@@ -29,8 +29,9 @@ impl BitmapGlyph {
 
 impl ::fallible::TryClone for BitmapGlyph {
     type Error = ::error::Error;
-    fn try_clone(&self) -> ::FtResult<Self> { unsafe {
+    fn try_clone(&self) -> ::FtResult<Self> { 
         let mut target = null_mut();
+    unsafe {
         ::error::from_ftret(ffi::FT_Glyph_Copy(self.raw as ffi::FT_Glyph, &mut target))?;
         Ok(BitmapGlyph::from_raw(self.library_raw, target as ffi::FT_BitmapGlyph))
     } }

--- a/src/glyph.rs
+++ b/src/glyph.rs
@@ -108,8 +108,9 @@ impl Glyph {
 
 impl ::fallible::TryClone for Glyph {
     type Error = ::error::Error;
-    fn try_clone(&self) -> FtResult<Self> { unsafe {
+    fn try_clone(&self) -> FtResult<Self> { 
         let mut target = null_mut();
+    unsafe {
         ::error::from_ftret(ffi::FT_Glyph_Copy(self.raw, &mut target))?;
         Ok(Glyph::from_raw(self.library_raw, target))
     } }

--- a/src/library.rs
+++ b/src/library.rs
@@ -43,12 +43,14 @@ impl Library {
     /// This function is used to create a new FreeType library instance and add the default
     /// modules. It returns a struct encapsulating the freetype library. The library is correctly
     /// discarded when the struct is dropped.
-    pub fn init() -> FtResult<Self> { unsafe {
+    pub fn init() -> FtResult<Self> { 
         let mut raw = null_mut();
-        ::error::from_ftret(ffi::FT_New_Library(&mut MEMORY, &mut raw))?;
-        ffi::FT_Add_Default_Modules(raw);
+        unsafe {
+            ::error::from_ftret(ffi::FT_New_Library(&mut MEMORY, &mut raw))?;
+            ffi::FT_Add_Default_Modules(raw);
+        }
         Ok(Library { raw })
-    } }
+    }
 
     /// Open a font file using its pathname. `face_index` should be 0 if there is only 1 font
     /// in the file.

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -86,34 +86,32 @@ impl<'a> Iterator for CurveIterator<'a> {
         if self.idx >= self.length {
             None
         } else {
-            unsafe {
-                let tag1 = self.tg(1);
+            let tag1 = unsafe { self.tg(1) };
 
-                let (shift, curve) = if (tag1 & TAG_ONCURVE) == TAG_ONCURVE {
-                    (1, Curve::Line(self.pt(1)))
-                } else if (tag1 & TAG_BEZIER3) == TAG_BEZIER3 {
-                    (3, Curve::Bezier3(self.pt(1), self.pt(2), self.pt(3)))
+            let (shift, curve) = unsafe { if (tag1 & TAG_ONCURVE) == TAG_ONCURVE {
+                (1, Curve::Line(self.pt(1)))
+            } else if (tag1 & TAG_BEZIER3) == TAG_BEZIER3 {
+                (3, Curve::Bezier3(self.pt(1), self.pt(2), self.pt(3)))
+            } else {
+                // We are some kind of quadratic Bezier.
+                // Quadratic Bezier curves have a special treatment in TTF outlines:
+                // as an optimization, curves are often constructed from sequences
+                // of off-curve control points. In this case, there are implied on-curve
+                // points in between each pair of off-curve points.
+                if (self.tg(2) & TAG_ONCURVE) == TAG_ONCURVE {
+                    (2, Curve::Bezier2(self.pt(1), self.pt(2)))
                 } else {
-                    // We are some kind of quadratic Bezier.
-                    // Quadratic Bezier curves have a special treatment in TTF outlines:
-                    // as an optimization, curves are often constructed from sequences
-                    // of off-curve control points. In this case, there are implied on-curve
-                    // points in between each pair of off-curve points.
-                    if (self.tg(2) & TAG_ONCURVE) == TAG_ONCURVE {
-                        (2, Curve::Bezier2(self.pt(1), self.pt(2)))
-                    } else {
-                        let pt = ffi::FT_Vector {
-                            x: (self.pt(1).x + self.pt(2).x) / 2,
-                            y: (self.pt(1).y + self.pt(2).y) / 2,
-                        };
+                    let pt = ffi::FT_Vector {
+                        x: (self.pt(1).x + self.pt(2).x) / 2,
+                        y: (self.pt(1).y + self.pt(2).y) / 2,
+                    };
 
-                        (1, Curve::Bezier2(self.pt(1), pt))
-                    }
-                };
+                    (1, Curve::Bezier2(self.pt(1), pt))
+                }
+            } };
 
-                self.idx += shift;
-                Some(curve)
-            }
+            self.idx += shift;
+            Some(curve)
         }
     }
 }
@@ -143,15 +141,13 @@ impl<'a> Iterator for ContourIterator<'a> {
         if self.contour_end_idx > self.last_end_idx {
             None
         } else {
-            unsafe {
-                let contour_end = *self.contour_end_idx;
-                let curves = CurveIterator::from_raw(self.outline, self.contour_start as isize,
-                                                     contour_end as isize);
-                self.contour_start = contour_end + 1;
-                self.contour_end_idx = self.contour_end_idx.offset(1);
+            let contour_end = unsafe { *self.contour_end_idx };
+            let curves = unsafe { CurveIterator::from_raw(self.outline, self.contour_start as isize,
+                                                    contour_end as isize) };
+            self.contour_start = contour_end + 1;
+            self.contour_end_idx = unsafe { self.contour_end_idx.offset(1) };
 
-                Some(curves)
-            }
+            Some(curves)
         }
     }
 }

--- a/src/tt_os2.rs
+++ b/src/tt_os2.rs
@@ -8,13 +8,11 @@ pub struct TrueTypeOS2Table {
 
 impl TrueTypeOS2Table {
     pub fn from_face(face: &mut Face) -> Option<Self> {
-        unsafe {
-            let os2 = ffi::FT_Get_Sfnt_Table(face.raw_mut() as *mut ffi::FT_FaceRec, ffi::ft_sfnt_os2) as ffi::TT_OS2_Internal;
-            if !os2.is_null() && (*os2).version != 0xffff {
-                Some(TrueTypeOS2Table { raw: os2 })
-            } else {
-                None
-            }
+        let os2 = unsafe { ffi::FT_Get_Sfnt_Table(face.raw_mut() as *mut ffi::FT_FaceRec, ffi::ft_sfnt_os2) as ffi::TT_OS2_Internal };
+        if unsafe { !os2.is_null() && (*os2).version != 0xffff } {
+            Some(TrueTypeOS2Table { raw: os2 })
+        } else {
+            None
         }
     }
 


### PR DESCRIPTION
In these functions you use the unsafe keyword for many safe expressions.

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 


Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 